### PR TITLE
PCPAY-2503 adds deprecation text on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+# :warning: Deprecated and Decommissioned :warning:
+**This repository is no longer used by any merchant. At the moment we don't support checkoutAPI-spike flow for any checkout merchants. As a matter of fact, it was created as a spike repo.**
+
 # CheckoutAPI Spike
 An experimental project
 


### PR DESCRIPTION
## Jira ticket
[PCPAY-2503](https://optile.atlassian.net/browse/PCPAY-2503)

## What
Updates `README` file

## Why
Deprecate the repo


[PCPAY-2503]: https://optile.atlassian.net/browse/PCPAY-2503?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ